### PR TITLE
Refactor AI prompts to use LangChain chains and add LangSmith push script

### DIFF
--- a/app/routers/ai/ai_prompts.py
+++ b/app/routers/ai/ai_prompts.py
@@ -1,4 +1,6 @@
-from langchain.prompts import ChatPromptTemplate
+"""Prompt templates used for AI generation."""
+
+from langchain_core.prompts import ChatPromptTemplate
 
 # Define the system prompt
 system_prompt = """You are here to listen to the user's story, think deeply about it, and then give them purpose and agency and an empirical path to follow.
@@ -49,20 +51,26 @@ Marcus Aurelius reminds us that virtue, duty, and rational reflection are the co
 
 
 # Define prompt templates with the system message
-summary_prompt = ChatPromptTemplate([
-    ("system", system_prompt),
-    ("user", """
-Based on the user's responses to the reflective questions below, create their purpose and a mantra.
+summary_prompt = ChatPromptTemplate.from_messages(
+    [
+        ("system", system_prompt),
+        (
+            "user",
+            """Based on the user's responses to the reflective questions below, create their purpose and a mantra.
 
 USER RESPONSES:
 {responses}
-""")
-])
+""",
+        ),
+    ]
+)
 
-full_plan_prompt = ChatPromptTemplate([
-    ("system", system_prompt),
-    ("user", """
-Based on the user's responses to the reflective questions below, create their mantra, purpose, next steps, daily plan, and obstacles.
+full_plan_prompt = ChatPromptTemplate.from_messages(
+    [
+        ("system", system_prompt),
+        (
+            "user",
+            """Based on the user's responses to the reflective questions below, create their mantra, purpose, next steps, daily plan, and obstacles.
 
 For each action item in the next steps and daily plan sections, assign one of these categories:
 health, learning, mindfulness, writing, planning, social, nutrition, rest, creativity, family, friendship, career, finance, medical, travel, hobbies, goals, reflection, gratitude, nature
@@ -87,5 +95,7 @@ For the obstacles section, identify both personal and external challenges the us
 
 USER RESPONSES:
 {responses}
-""")
-])
+""",
+        ),
+    ]
+)

--- a/scripts/upload_prompts.py
+++ b/scripts/upload_prompts.py
@@ -1,0 +1,24 @@
+"""Upload Pathlight prompts and models to LangSmith."""
+
+from langchain import hub as prompts
+from langchain_openai import ChatOpenAI
+
+from app.routers.ai.ai_prompts import summary_prompt, full_plan_prompt
+from app.routers.ai.ai_models import SummaryOutput, FullPlanOutput
+
+
+def push_prompts() -> None:
+    """Push the prompt chains to LangSmith and print their URLs."""
+    model = ChatOpenAI(model="gpt-4o-mini")
+
+    summary_chain = summary_prompt | model.with_structured_output(SummaryOutput)
+    summary_url = prompts.push("pathlight-summary-generator", summary_chain)
+    print(f"Summary prompt uploaded to: {summary_url}")
+
+    full_chain = full_plan_prompt | model.with_structured_output(FullPlanOutput)
+    full_url = prompts.push("pathlight-full-plan-generator", full_chain)
+    print(f"Full plan prompt uploaded to: {full_url}")
+
+
+if __name__ == "__main__":
+    push_prompts()


### PR DESCRIPTION
## Summary
- refactor `ai_prompts` to use `ChatPromptTemplate.from_messages`
- refactor `ai_generation` to build chains using `RunnableLambda`
- add `scripts/upload_prompts.py` for pushing prompt chains to LangSmith

## Testing
- `poetry run pytest tests/unit/routers/ai/test_generation.py::test_generate_purpose -q`
- `poetry run pytest` *(fails: Missing Stripe configuration and other environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68459a94943c832c98a7e38530256c59