### PR TITLE
Add research post on purpose across life stages

### DIFF
--- a/app/templates/blog/index.html
+++ b/app/templates/blog/index.html
@@ -278,6 +278,17 @@
                     <a href="/blog/posts/purpose-beyond-passion-when-follow-your-passion-is-bad-advice" class="post-link">Read More →</a>
                 </div>
             </div>
+            <div class="post-card">
+                <img src="/static/images/15TheAshes.png" alt="Research on Purpose Across Different Life Stages" class="post-image">
+                <div class="post-content">
+                    <h3 class="post-title">Research on Purpose Across Different Life Stages</h3>
+                    <div class="post-meta">
+                        <i class="fas fa-calendar"></i> December 10, 2025
+                    </div>
+                    <p class="post-excerpt">Learn how scientists track purpose from childhood through older adulthood, and discover tips for cultivating meaning at every age...</p>
+                    <a href="/blog/posts/research-on-purpose-across-different-life-stages" class="post-link">Read More →</a>
+                </div>
+            </div>
             </div>
         </div>
         

--- a/app/templates/blog/posts/research-on-purpose-across-different-life-stages.html
+++ b/app/templates/blog/posts/research-on-purpose-across-different-life-stages.html
@@ -1,0 +1,89 @@
+{% extends "blog/post_template.html" %}
+
+{% set title = "Research on Purpose Across Different Life Stages" %}
+{% set description = "Explore how our sense of purpose evolves from childhood through older adulthood, with research insights on what fosters meaning at every age." %}
+{% set keywords = "purpose across life stages, life purpose development, adolescent purpose, adult purpose research, meaning in older adulthood" %}
+{% set image_url = "/static/images/15TheAshes.png" %}
+{% set published_date = "2025-12-10" %}
+{% set modified_date = "2025-12-10" %}
+{% set author = "Sarah Johnson" %}
+{% set category = "Science & Research" %}
+{% set tags = ["purpose", "lifespan", "development", "research", "meaning"] %}
+{% set related_posts = [
+    {
+        "title": "The Psychology of Flow States and Purpose",
+        "image_url": "/static/images/16TheHorizon.png",
+        "url": "/blog/posts/the-psychology-of-flow-states-and-purpose"
+    },
+    {
+        "title": "Jonathan Haidt's Moral Foundations Theory: How Values Shape Purpose",
+        "image_url": "/static/images/14TheImprint.png",
+        "url": "/blog/posts/jonathan-haidts-moral-foundations-values-shape-purpose"
+    }
+] %}
+
+{% block post_content %}
+<h2>Why Study Purpose Over a Lifetime?</h2>
+<p>Researchers have long noted that a sense of purpose is linked with higher motivation, resilience, and life satisfaction. Yet purpose rarely stays static. Life experiences, relationships, and cultural expectations continually shape what we find meaningful. Examining purpose across the lifespan helps illuminate how these factors interact. It also shows that cultivating purpose is relevant whether you are seven or seventy. Understanding the science behind purpose development empowers us to nurture it intentionally, making each life stage a fertile ground for meaning.</p>
+<p>By exploring age-specific research, we gain insight into universal principles that underlie purposeful living and learn how to apply them at different milestones.</p>
+
+<h2>Purpose From the Start</h2>
+<p>Developmental psychologist <a href="https://ed.stanford.edu/faculty/wdamon" target="_blank">William Damon</a> defines purpose as a "stable and generalized intention to accomplish something that is at once meaningful to the self and of consequence to the world." Research suggests that even in childhood, seeds of purpose begin to take root. Damon has found that when young people engage in projects that contribute to something larger than themselves&mdash;such as community service or creative collaboration&mdash;they gain a stronger sense of direction. Encouraging curiosity and agency in early life lays the groundwork for purposeful growth.</p>
+
+<h2>Adolescence: Experimentation and Identity</h2>
+<p>Studies show adolescence is a critical period for exploring identity and values. According to research published in <em>Child Development</em>, teens who participate in meaningful extracurricular activities report higher levels of purpose and motivation. Providing opportunities to try different roles&mdash;from sports to student leadership to volunteering&mdash;helps adolescents discover what resonates. Mentorship also plays a key role during this stage, guiding young people as they turn personal interests into emerging life aims.</p>
+
+<h2>Early Adulthood: Purpose and Career Choices</h2>
+<p>As individuals enter their twenties and thirties, purpose often becomes closely tied to career decisions. A long-term study from the <a href="https://www.youthdevelopmentinstitute.org" target="_blank">Youth Development Institute</a> found that early adults who perceive their work as contributing to a larger mission experience greater job satisfaction and persistence. This finding echoes insights from our post on <a href="/blog/posts/purpose-beyond-passion-when-follow-your-passion-is-bad-advice">Purpose Beyond Passion</a>, which emphasizes aligning values with skills. Building competencies while remaining flexible can help emerging adults craft careers that feel both purposeful and sustainable.</p>
+
+<h2>The Role of Family and Culture</h2>
+<p>Family expectations and cultural narratives often influence early adulthood choices. In collectivist cultures, purpose may be intertwined with familial duty or community well-being. In more individualistic societies, personal ambition might take center stage. Studies reported in <em>The Journal of Youth and Adolescence</em> suggest that purpose clarity increases when young adults have supportive networks that respect their autonomy while reinforcing community values. Keeping lines of communication open with loved ones and mentors can provide the guidance needed to craft a purpose that feels authentic.</p>
+
+<h2>Midlife: Reassessing Meaning</h2>
+<p>Midlife often brings a period of reevaluation. Psychologist Erik Erikson described this stage as a conflict between generativity and stagnation. Research published in <em>The Journal of Positive Psychology</em> shows that adults in their forties and fifties who engage in generative activities&mdash;such as mentoring, creative projects, and community leadership&mdash;report higher life satisfaction and well-being. A sense of purpose can counteract the so-called "midlife slump" by providing a renewed vision for the years ahead.</p>
+
+<h2>Transitions and Life Crises</h2>
+<p>Major transitions&mdash;graduating from school, changing careers, becoming a parent, or facing health challenges&mdash;often prompt people to reconsider what matters most. During these times, psychologists recommend reflective practices like journaling or counseling to realign one's goals. Purpose can act as a compass through uncertainty, helping individuals see opportunities for growth even when circumstances are turbulent. Studies of post-traumatic growth reveal that hardships can clarify purpose when individuals frame adversity as a catalyst for positive change.</p>
+
+<h2>Later Life: Purpose and Healthy Aging</h2>
+<p>A growing body of evidence links purpose in older adulthood with better physical health and cognitive function. In a large study cited in our <a href="/blog/posts/purpose-and-longevity-research">purpose and longevity research</a> post, adults with a strong sense of meaning lived longer and experienced slower decline in daily functioning. Engagement in purposeful activities&mdash;from volunteering to creative hobbies&mdash;supports mental agility and a positive outlook, underscoring that it's never too late to cultivate purpose.</p>
+
+<h2>Across the Lifespan: Common Threads</h2>
+<p>While purpose manifests differently at various stages, researchers highlight common themes. Purpose tends to flourish when people connect personal values with contributions to others, seek growth-oriented challenges, and maintain supportive relationships. Intentional reflection throughout life&mdash;such as journaling or using a <a href="/form">research-backed purpose discovery tool</a>&mdash;can reveal how your motivations evolve. As philosopher Viktor Frankl observed, "Life is never made unbearable by circumstances, but only by lack of meaning." Purpose provides resilience no matter your age.</p>
+
+<h2>Purpose, Health, and Resilience</h2>
+<p>Health psychologists have found strong correlations between purposeful living and markers of physical well-being, including lower inflammation and improved cardiovascular health. Purposeful individuals also tend to engage in healthier habits such as regular exercise and social connection. According to a 20-year longitudinal study from the University of Michigan, adults with a clear sense of purpose were significantly less likely to experience cognitive decline. These findings underline that nurturing purpose isn't merely a philosophical exercise&mdash;it has tangible benefits for body and mind.</p>
+
+<h2>Purpose and Parenting</h2>
+<p>For many adults, raising children introduces new dimensions of purpose. Research from the <em>Journal of Marriage and Family</em> suggests that parents who view caregiving as a meaningful vocation experience greater well-being, even amid the stresses of child-rearing. Sharing family stories about values and resilience can help children develop their own sense of direction. At the same time, it is important for parents to retain personal goals beyond their caregiving role, modeling lifelong growth for the next generation.</p>
+
+<h2>Purpose in Retirement</h2>
+<p>Retirement does not have to signal the end of purposeful engagement. Studies from the Stanford Center on Longevity show that retirees who participate in volunteering, part-time work, or creative pursuits report higher life satisfaction than those who fully withdraw from productive activities. Purpose in later life often revolves around legacy&mdash;mentoring younger generations, supporting community projects, or pursuing long-delayed passions. The flexibility of retirement can provide fertile ground for exploring new facets of meaning.</p>
+
+<h2>Practical Strategies for Every Stage</h2>
+<ul>
+    <li><strong>Encourage exploration:</strong> For youth and adolescents, varied experiences plant seeds for future direction.</li>
+    <li><strong>Align work with values:</strong> Young adults can experiment with roles that express both competence and contribution.</li>
+    <li><strong>Invest in relationships:</strong> Across all ages, supportive mentors and peers reinforce meaning.</li>
+    <li><strong>Stay open to change:</strong> Midlife offers a chance to revise goals, while later life invites new avenues of service.</li>
+    <li><strong>Reflect regularly:</strong> Purpose evolves; intentional reflection helps you notice shifts and recalibrate.</li>
+</ul>
+
+<h2>Refining Purpose Through Reflection</h2>
+<p>Purpose can evolve as you gather new experiences. Setting aside time each year to review your goals and motivations can help you stay aligned with what matters most. Practices like mindfulness, community service, and skill development foster a feedback loop where purpose and growth reinforce each other. Consider creating a purpose journal or partnering with a coach or mentor to explore how your sense of meaning is shifting. By returning to reflective practices regularly, you transform purpose from a destination into an ongoing dialogue with your life.</p>
+
+<h2>Connecting the Dots with Pathlight</h2>
+<p>At Pathlight, we recognize that purpose is a journey unfolding over a lifetime. Our research-backed purpose discovery process combines psychological insight with modern technology to help you identify meaningful patterns at any age. By reflecting on your experiences&mdash;whether you're choosing a college major, navigating a career change, or seeking renewed vitality in retirement&mdash;our questions guide you toward actions that honor your evolving values.</p>
+
+<blockquote>
+    <p>"Purpose is not a luxury of youth or a relic of old age; it is the thread that weaves meaning through every chapter of life."</p>
+    <div class="citation">&mdash; Adapted from the work of William Damon</div>
+</blockquote>
+
+<p>Whether you are just starting out or reflecting on decades of experience, purpose remains a dynamic force. Committing to growth and service ensures that each chapter of life offers new chances to align with what matters most. By observing how purpose evolves, you can meet transitions with curiosity rather than fear and cultivate a sense of meaning that endures.</p>
+
+<p>Ready to explore how purpose can deepen your life at this very stage? Start your personalized journey with Pathlight today.</p>
+<p class="post-cta">
+    <a href="/form" class="cta-button">Discover Your Purpose with Pathlight</a>
+</p>
+{% endblock %}

--- a/memory-bank/blog-topics.md
+++ b/memory-bank/blog-topics.md
@@ -240,7 +240,7 @@ This category explores evidence-based insights on purpose, drawing from psycholo
     - Understanding value differences in purpose expression
     - Using moral foundations insights for purpose clarity
 
-36. **"Research on Purpose Across Different Life Stages"**
+36. ~~**"Research on Purpose Across Different Life Stages"**~~ (Completed: June 23, 2025)
     - How purpose manifests in childhood, adolescence, adulthood, and older age
     - Research on purpose development throughout the lifespan
     - Critical periods and transitions in purpose formation


### PR DESCRIPTION
## Summary
- expand research post on purpose across different life stages to ~1500 words
- cross off the corresponding topic in blog-topics list

## Testing
- `poetry install --with dev --no-root`
- `poetry run pytest` *(fails: ArgumentError - Expected string or URL object, got None)*

------
https://chatgpt.com/codex/tasks/task_e_685963450cfc832cbf4b51b7ba7607af